### PR TITLE
feat: add floating preference controls for unauthenticated users

### DIFF
--- a/apps/web/src/components/UnauthenticatedPreferencesFloat.tsx
+++ b/apps/web/src/components/UnauthenticatedPreferencesFloat.tsx
@@ -1,0 +1,24 @@
+import { ModeToggle } from "@tasks/ui/components/mode-toggle";
+import { LocaleSwitcher } from "@/components/LocaleSwitcher";
+import { useCurrentUser } from "@/providers/SessionProvider";
+
+/**
+ * Floating preferences widget for unauthenticated users.
+ * Shows locale and theme controls in the top-right corner.
+ * Automatically hides when user is authenticated.
+ */
+export function UnauthenticatedPreferencesFloat() {
+  const { currentUser, isLoading } = useCurrentUser();
+
+  // Don't show anything while loading or if user is authenticated
+  if (isLoading || currentUser) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-4 right-4 z-50 flex items-center gap-2 rounded-lg border border-gray-200 bg-white/95 p-2 shadow-md backdrop-blur-sm dark:border-slate-800 dark:bg-slate-950/95">
+      <LocaleSwitcher />
+      <ModeToggle />
+    </div>
+  );
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import type { UserPreferences } from "@tasks/core";
 import { Toaster } from "@tasks/ui/components/sonner";
 import { ThemeProvider } from "@tasks/ui/components/theme-provider";
 import type { authClient } from "@/auth-client";
+import { UnauthenticatedPreferencesFloat } from "@/components/UnauthenticatedPreferencesFloat";
 import { env } from "@/env";
 import { useI18nContext } from "@/i18n/i18n-react";
 import type { Locales } from "@/i18n/i18n-types";
@@ -267,6 +268,7 @@ function BodyContent({ error }: { error?: unknown }) {
   return (
     <>
       {error ? <ErrorBoundaryContent error={error} /> : <AppLayout />}
+      <UnauthenticatedPreferencesFloat />
       <Toaster />
       {env.VITE_ENVIRONMENT === "local" && (
         <TanStackDevtools


### PR DESCRIPTION
- Create UnauthenticatedPreferencesFloat component with locale and theme switchers
- Component only visible to unauthenticated users in top-right corner
- Uses discreet design with semi-transparent background
- Automatically hides when user authenticates
- Reuses existing LocaleSwitcher and ModeToggle components

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a top-right floating widget with locale and theme controls that appears only for unauthenticated users.
> 
> - **UI (web)**:
>   - **New component**: `apps/web/src/components/UnauthenticatedPreferencesFloat.tsx`
>     - Renders `LocaleSwitcher` and `ModeToggle` for unauthenticated users; hidden while loading/authenticated.
>     - Fixed, top-right floating container with light/dark-friendly styling.
>   - **Integration**: `apps/web/src/routes/__root.tsx`
>     - Adds `UnauthenticatedPreferencesFloat` to `BodyContent` for global availability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6ec14856ff64fe67dac4afc20b0b7b81669b312. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->